### PR TITLE
Updated udon13/config.h to compile against latest qmk

### DIFF
--- a/qmk-madnoodle-files/themadnoodle/udon13/config.h
+++ b/qmk-madnoodle-files/themadnoodle/udon13/config.h
@@ -19,14 +19,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "config_common.h"
 
-/* USB Device descriptor parameter */
-#define VENDOR_ID       0xFEED
-#define PRODUCT_ID      0x1701
-#define DEVICE_VER      0x0001
-#define MANUFACTURER    The Mad Noodle
-#define PRODUCT         Udon13
-#define DESCRIPTION     Udon13 macro keypad
-
 /* key matrix size */
 #define MATRIX_ROWS 4
 #define MATRIX_COLS 4
@@ -34,13 +26,22 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* NCC-1701-KB PCB default pin-out */
 #define MATRIX_ROW_PINS { F7, F1, D6, D7 }
 #define MATRIX_COL_PINS { F0, F5, F4, F6 }
-#define UNUSED_PINS
 
 /* RGB BackLight */
 #define RGB_DI_PIN B7
 #define RGBLED_NUM 6
 #define RGBLIGHT_SLEEP
-#define RGBLIGHT_ANIMATIONS
+#define RGBLIGHT_EFFECT_BREATHING
+
+#define RGBLIGHT_EFFECT_RAINBOW_MOOD
+#define RGBLIGHT_EFFECT_RAINBOW_SWIRL
+#define RGBLIGHT_EFFECT_SNAKE
+#define RGBLIGHT_EFFECT_KNIGHT
+#define RGBLIGHT_EFFECT_CHRISTMAS
+#define RGBLIGHT_EFFECT_STATIC_GRADIENT
+#define RGBLIGHT_EFFECT_RGB_TEST
+#define RGBLIGHT_EFFECT_ALTERNATING
+#define RGBLIGHT_EFFECT_TWINKLE
 
 /*RGB Defaults*/
 #define RGBLIGHT_DEFAULT_MODE RGBLIGHT_MODE_RAINBOW_SWIRL

--- a/qmk-madnoodle-files/themadnoodle/udon13/info.json
+++ b/qmk-madnoodle-files/themadnoodle/udon13/info.json
@@ -1,7 +1,13 @@
 {
   "keyboard_name": "Udon13",
+  "manufacturer": "The Mad Noodle",
   "url": "instagram.com/the_mad_noodle",
   "maintainer": "The-Mad-Noodle",
+  "usb": {
+    "vid": "0xFEED",
+    "pid": "0x1701",
+    "device_version": "0.0.1"
+  },
   "width": 4,
   "height": 4,
   "layouts": {


### PR DESCRIPTION
I'm new to QMK, so this is something of a shot in the dark.

The version of this file included here does not compile against the latest QMK, as set up per the instructions.  With a little examination of [the config.h](https://github.com/qmk/qmk_firmware/commits/master/keyboards/themadnoodle/noodlepad/config.h) for the upstream noodlepad, it looks like some of the directives used here have been retired or moved elsewhere; I've copied that history over to the udon13's config.h, using the values that were already present where it made sense.

I compiled this and installed it on my unit, and it appears to work the same as the image it came with.